### PR TITLE
Ajustes no Gemfile

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,3 +1,26 @@
+# Version 0.3.4
+Release date: 15/09/2018
+
+### Adicionado
+
+- Nada
+
+### Corrigido
+
+- Nada
+
+
+### Mudado
+
+- SitePrism foi mudado de '2.15' para '2.15.1', devido a algumas melhorias de performance com o cucumber;
+- Capybara versão alterada de '3.0.3' para '<3.3', versão aconselhada pelo pessoal do siteprism;
+- Foi setado a versão do Selenium '~>3.4', versão aconselhada pelo pessoal do siteprism;
+- Regex no Hooks para obter o nome do relatório foi reduzida para somente uma linha.
+
+### Removido
+
+- Nada
+
 # Version 0.3.3
 Release date: 14/09/2018
 

--- a/history.md
+++ b/history.md
@@ -1,0 +1,59 @@
+# Version 0.3.3
+Release date: 14/09/2018
+
+### Adicionado
+
+- Nada
+
+### Corrigido
+
+- bug da gem ao gerar projeto.
+
+
+### Mudado
+
+- Nada
+
+### Removido
+
+- Nada
+
+# Version 0.3.2
+Release date: 14/09/2018
+
+### Adicionado
+
+- Nada
+
+### Corrigido
+
+- Ao digitar ```rubygene --version``` não estava funcionando. Agora está corrigido.
+- Melhorias no código pedidos pelo rubocop. 
+- Melhoria na tradução usando I18n 
+
+### Mudado
+
+- nada
+
+### Removido
+
+- Dependência do gerkin para traduzir as features.
+
+# Version 0.3.1
+Release date: 13/09/2018
+
+### Adicionado
+
+- Arquivo com histórico da gem das atualizaçōes
+
+### Corrigido
+
+- Descrição da gem spec.description
+
+### Mudado
+
+- nada
+
+### Removido
+
+- nada

--- a/lib/SkeletonMobile/features/support/hooks.rb
+++ b/lib/SkeletonMobile/features/support/hooks.rb
@@ -13,7 +13,7 @@ def scroll_screen(xone, yone, xtwo, ytwo)
 end
 
 After do |scenario|
-  scenario_name = scenario.name..gsub(/[^A-Za-z ]/, '').gsub(/\s+/, '_')
+  scenario_name = scenario.name.gsub(/[^A-Za-z ]/, '').gsub(/\s+/, '_')
 
   if scenario.failed?
     take_screenshot(scenario_name.downcase!, 'failed')

--- a/lib/SkeletonMobile/features/support/hooks.rb
+++ b/lib/SkeletonMobile/features/support/hooks.rb
@@ -13,7 +13,7 @@ def scroll_screen(xone, yone, xtwo, ytwo)
 end
 
 After do |scenario|
-  scenario_name = scenario.name.gsub(/\s+/, '_').tr('/', '_')
+  scenario_name = scenario.name..gsub(/[^A-Za-z ]/, '').gsub(/\s+/, '_')
 
   if scenario.failed?
     take_screenshot(scenario_name.downcase!, 'failed')

--- a/lib/SkeletonWeb/Gemfile
+++ b/lib/SkeletonWeb/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 
 gem 'capybara', '<3.3'
 gem 'cucumber'
-gem 'selenium-webdriver', '~> 3.4'
+gem 'selenium-webdriver', '~>3.4'
 gem 'rspec'
 gem 'site_prism', '2.15.1'
 gem 'syntax'

--- a/lib/SkeletonWeb/Gemfile
+++ b/lib/SkeletonWeb/Gemfile
@@ -1,10 +1,10 @@
 source 'http://rubygems.org'
 
-gem 'capybara', '3.0.3'
+gem 'capybara', '<3.3'
 gem 'cucumber'
-gem 'selenium-webdriver'
+gem 'selenium-webdriver', '~> 3.4'
 gem 'rspec'
-gem 'site_prism', '2.15'
+gem 'site_prism', '2.15.1'
 gem 'syntax'
 gem 'rubocop'
 gem 'byebug'

--- a/lib/SkeletonWeb/features/support/hooks.rb
+++ b/lib/SkeletonWeb/features/support/hooks.rb
@@ -1,7 +1,7 @@
 require_relative 'helper.rb'
 
 After do |scenario|
-  scenario_name = scenario.gsub(/[^A-Za-z ]/, '').gsub(/\s+/, '_')
+  scenario_name = scenario.name.gsub(/[^A-Za-z ]/, '').gsub(/\s+/, '_')
 
   if scenario.failed?
     take_screenshot(scenario_name.downcase!, 'failed')

--- a/lib/SkeletonWeb/features/support/hooks.rb
+++ b/lib/SkeletonWeb/features/support/hooks.rb
@@ -1,11 +1,7 @@
 require_relative 'helper.rb'
 
 After do |scenario|
-  scenario_name = scenario.name.gsub(/\s+/, '_').tr('/', '_')
-  scenario_name = scenario_name.gsub(',', '')
-  scenario_name = scenario_name.gsub('(', '')
-  scenario_name = scenario_name.gsub(')', '')
-  scenario_name = scenario_name.gsub('#', '')
+  scenario_name = scenario.gsub(/[^A-Za-z ]/, '').gsub(/\s+/, '_')
 
   if scenario.failed?
     take_screenshot(scenario_name.downcase!, 'failed')


### PR DESCRIPTION
- SitePrism foi mudado de '2.15' para '2.15.1', devido a algumas melhorias de performance com o cucumber;
- Capybara versão alterada de '3.0.3' para '<3.3', versão aconselhada pelo pessoal do siteprism;
- Foi setado a versão do Selenium '~>3.4', versão aconselhada pelo pessoal do siteprism;
- Regex no Hooks para obter o nome do relatório foi reduzida para somente uma linha.